### PR TITLE
Updated smoke_tests.yml with missing environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ Through the CI a smaller matrix (using inventory):
   * Your user must be able to log in as both root and non root user against all hosts
   * Rootful tests disabled in CI as we are unable to write to /usr and /etc
 
+
+## Overwriting SKUPPER_CLI and SKUPPER_ROUTER images
+
+The default images used by the smoke tests are based on the binaries available at the time of the release. If you want to use a different image, you can overwrite the `cli_image` and `router_image` variables when running the playbook.
+
+```yaml
+-e cli_image=<YOUR_CLI_IMAGE> -e router_image=<YOUR_ROUTER_IMAGE>
+```
+
 ## Included content/ Directory Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Through the CI a smaller matrix (using inventory):
 
 ## Overwriting SKUPPER_CLI and SKUPPER_ROUTER images
 
-The default images used by the smoke tests are based on the binaries available at the time of the release. If you want to use a different image, you can overwrite the `cli_image` and `router_image` variables when running the playbook.
+The default images used by the smoke tests are based on the binaries available at the time of the release. If you want to use a different image, you can overwrite the `run_cli_image` and `router_image` variables when running the playbook.
 
 ```yaml
--e cli_image=<YOUR_CLI_IMAGE> -e router_image=<YOUR_ROUTER_IMAGE>
+-e run_cli_image=<YOUR_CLI_IMAGE> -e router_image=<YOUR_ROUTER_IMAGE>
 ```
 
 ## Included content/ Directory Structure

--- a/smoke_tests.yml
+++ b/smoke_tests.yml
@@ -1,6 +1,9 @@
 ---
 - name: Nonkube smoke test as non root
   hosts: rootless
+  environment:
+    SKUPPER_ROUTER_IMAGE: "{{ router_image | default('') }}"
+    SKUPPER_CLI_IMAGE: "{{ cli_image | default('') }}"
   tasks:
     - name: Rootless smoke tests tasks
       block:
@@ -19,6 +22,9 @@
 
 - name: Nonkube smoke test as root
   hosts: rootful
+  environment:
+    SKUPPER_ROUTER_IMAGE: "{{ router_image | default('') }}"
+    SKUPPER_CLI_IMAGE: "{{ cli_image | default('') }}"
   tasks:
     - name: Rootful smoke tests tasks
       block:

--- a/smoke_tests.yml
+++ b/smoke_tests.yml
@@ -3,7 +3,7 @@
   hosts: rootless
   environment:
     SKUPPER_ROUTER_IMAGE: "{{ router_image | default('') }}"
-    SKUPPER_CLI_IMAGE: "{{ cli_image | default('') }}"
+    SKUPPER_CLI_IMAGE: "{{ run_cli_image | default('') }}"
   tasks:
     - name: Rootless smoke tests tasks
       block:
@@ -24,7 +24,7 @@
   hosts: rootful
   environment:
     SKUPPER_ROUTER_IMAGE: "{{ router_image | default('') }}"
-    SKUPPER_CLI_IMAGE: "{{ cli_image | default('') }}"
+    SKUPPER_CLI_IMAGE: "{{ run_cli_image | default('') }}"
   tasks:
     - name: Rootful smoke tests tasks
       block:


### PR DESCRIPTION
- Motivation and Context
The smoke_tests.yml file was missing necessary environment variables for SKUPPER_ROUTER_IMAGE and SKUPPER_CLI_IMAGE.

- How Has This Been Tested?
Tested by running the smoke tests with the updated environment variables and ensuring they work as expected.
