### PR TITLE
Individual inventory and proper fail

### DIFF
--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
@@ -15,7 +15,7 @@
     argv: "{{ cleanup_command + [ns] }}"
     chdir: "hello-world"
   environment:
-    SKUPPER_PLATFORM: "podman"
+    SKUPPER_PLATFORM: "{{ run_platform }}"
   loop:
     - "east"
     - "west"

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
@@ -15,7 +15,7 @@
     argv: "{{ cleanup_command + [ns] }}"
     chdir: "hello-world"
   environment:
-    SKUPPER_PLATFORM: "{{ run_platform }}"
+    SKUPPER_PLATFORM: "{{ cleanup_platform }}"
   loop:
     - "east"
     - "west"

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/cleanup/tasks/remove.yml
@@ -16,6 +16,7 @@
     chdir: "hello-world"
   environment:
     SKUPPER_PLATFORM: "{{ cleanup_platform }}"
+    DOCKER_HOST: "{{ DOCKER_HOST | default(omit) }}"
   loop:
     - "east"
     - "west"

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
@@ -11,6 +11,7 @@
         url: "{{ run_cli_url }}"
         dest: "{{ cli_archive_tmp.path }}"
         mode: '0644'
+        force: true
 
     - name: Unarchive the CLI
       ansible.builtin.unarchive:

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
@@ -57,6 +57,7 @@
     chdir: "hello-world"
   environment:
     SKUPPER_PLATFORM: "{{ run_platform }}"
+    DOCKER_HOST: "{{ DOCKER_HOST | default(omit) }}"
   register: run_bootstrap
   changed_when: not run_bootstrap.failed
 
@@ -79,5 +80,6 @@
     chdir: "hello-world"
   environment:
     SKUPPER_PLATFORM: "{{ run_platform }}"
+    DOCKER_HOST: "{{ DOCKER_HOST | default(omit) }}"
   register: run_bootstrap
   changed_when: not run_bootstrap.failed

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
@@ -15,6 +15,7 @@
     - name: Unarchive the CLI
       ansible.builtin.unarchive:
         src: "{{ cli_archive_tmp.path }}"
+        remote_src: true
         dest: hello-world/
         mode: '0755'
 

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/bootstrap.yml
@@ -1,10 +1,29 @@
-- name: Download and unarchive the CLI
-  ansible.builtin.unarchive:
-    src: "{{ run_cli_url }}"
-    dest: hello-world/
-    remote_src: true
-    mode: '0755'
+- name: Download and install the CLI
   when: not ('' == run_cli_url)
+  block:
+    - name: Create a temporary file for the CLI archive
+      ansible.builtin.tempfile:
+        suffix: ".tar.gz"
+      register: cli_archive_tmp
+
+    - name: Download the CLI archive
+      ansible.builtin.get_url:
+        url: "{{ run_cli_url }}"
+        dest: "{{ cli_archive_tmp.path }}"
+        mode: '0644'
+
+    - name: Unarchive the CLI
+      ansible.builtin.unarchive:
+        src: "{{ cli_archive_tmp.path }}"
+        dest: hello-world/
+        mode: '0755'
+
+  always:
+    - name: Remove the temporary CLI archive
+      ansible.builtin.file:
+        path: "{{ cli_archive_tmp.path }}"
+        state: absent
+      when: cli_archive_tmp is defined
 
 - name: Download bootstrap.sh
   ansible.builtin.get_url:

--- a/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/main.yml
+++ b/collections/ansible_collections/fgiorgetti/nonkube_smoke_tests/roles/run/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Set cleanup platform fact
+  ansible.builtin.set_fact:
+    cleanup_platform: "{{ run_platform }}"
+
 - name: Starting smoke test using {{ run_command + [' with ', run_platform] }}
   ansible.builtin.debug:
     msg: "Starting smoke test using {{ run_command + [' with ', run_platform] }}"

--- a/inventory-individual/group_vars/rootful.yml
+++ b/inventory-individual/group_vars/rootful.yml
@@ -1,0 +1,3 @@
+---
+ansible_user: root
+skupper_home: /var/lib/skupper

--- a/inventory-individual/group_vars/rootful_docker.yml
+++ b/inventory-individual/group_vars/rootful_docker.yml
@@ -1,0 +1,5 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "docker" }
+ce_commands:
+  - systemctl enable --now docker.socket

--- a/inventory-individual/group_vars/rootful_linux.yml
+++ b/inventory-individual/group_vars/rootful_linux.yml
@@ -1,0 +1,4 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "linux" }
+ce_commands: []

--- a/inventory-individual/group_vars/rootful_podman.yml
+++ b/inventory-individual/group_vars/rootful_podman.yml
@@ -1,0 +1,5 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "podman" }
+ce_commands:
+  - systemctl enable --now podman.socket

--- a/inventory-individual/group_vars/rootless.yml
+++ b/inventory-individual/group_vars/rootless.yml
@@ -1,0 +1,3 @@
+---
+ansible_user: "{{ rootless_ansible_user | default('ci') }}"
+skupper_home: "/home/{{ ansible_user }}/.local/share/skupper"

--- a/inventory-individual/group_vars/rootless_docker.yml
+++ b/inventory-individual/group_vars/rootless_docker.yml
@@ -2,6 +2,7 @@
 matrix:
   - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "docker" }
 ce_commands:
+  # https://docs.docker.com/engine/security/rootless/
   - dockerd-rootless-setuptool.sh  install --force
 #  - systemctl --user enable --now docker.socket
 DOCKER_HOST: "unix://{{ ansible_env.XDG_RUNTIME_DIR }}/docker.sock"

--- a/inventory-individual/group_vars/rootless_docker.yml
+++ b/inventory-individual/group_vars/rootless_docker.yml
@@ -4,3 +4,5 @@ matrix:
 ce_commands:
   - dockerd-rootless-setuptool.sh  install --force
 #  - systemctl --user enable --now docker.socket
+DOCKER_HOST: "unix://{{ ansible_env.XDG_RUNTIME_DIR }}/docker.sock"
+

--- a/inventory-individual/group_vars/rootless_docker.yml
+++ b/inventory-individual/group_vars/rootless_docker.yml
@@ -1,0 +1,5 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "docker" }
+ce_commands:
+  - systemctl --user enable --now docker.socket

--- a/inventory-individual/group_vars/rootless_docker.yml
+++ b/inventory-individual/group_vars/rootless_docker.yml
@@ -2,4 +2,5 @@
 matrix:
   - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "docker" }
 ce_commands:
-  - systemctl --user enable --now docker.socket
+  - dockerd-rootless-setuptool.sh  install --force
+#  - systemctl --user enable --now docker.socket

--- a/inventory-individual/group_vars/rootless_linux.yml
+++ b/inventory-individual/group_vars/rootless_linux.yml
@@ -1,0 +1,4 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "linux" }
+ce_commands: []

--- a/inventory-individual/group_vars/rootless_podman.yml
+++ b/inventory-individual/group_vars/rootless_podman.yml
@@ -1,0 +1,5 @@
+---
+matrix:
+  - { command: ["skupper", "system", "start"], remove: ["skupper", "system", "stop", "-n"], platform: "podman" }
+ce_commands:
+  - systemctl --user enable --now podman.socket

--- a/inventory-individual/hosts.yml
+++ b/inventory-individual/hosts.yml
@@ -1,0 +1,13 @@
+---
+all:
+  children:
+    rootful:
+      children:
+        rootful_docker:
+        rootful_podman:
+        rootful_linux:
+    rootless:
+      children:
+        rootless_docker:
+        rootless_podman:
+        rootless_linux:

--- a/smoke_tests.yml
+++ b/smoke_tests.yml
@@ -20,6 +20,10 @@
           ansible.builtin.include_role:
             name: fgiorgetti.nonkube_smoke_tests.cleanup
 
+        - name: Re-raise original failure
+          ansible.builtin.fail:
+            msg: "{{ ansible_failed_task.name }}: {{ ansible_failed_result.msg | default(ansible_failed_result.stderr | default('unknown error')) }}"
+
 - name: Nonkube smoke test as root
   hosts: rootful
   environment:
@@ -40,3 +44,7 @@
         - name: Cleanup rootful smoke tests
           ansible.builtin.include_role:
             name: fgiorgetti.nonkube_smoke_tests.cleanup
+
+        - name: Re-raise original failure
+          ansible.builtin.fail:
+            msg: "{{ ansible_failed_task.name }}: {{ ansible_failed_result.msg | default(ansible_failed_result.stderr | default('unknown error')) }}"


### PR DESCRIPTION
- Add new `inventory-individual`, where each test type ({docker,podman,linux}-{rootful,rootless}) has its own group
  - On this inventory, rootless-docker uses `dockerd-rootless-setuptool.sh`, which provides for a better rootless test for docker (we may investigate using that in other inventories)
  - For that to work, we set a new `DOCKER_HOST` env var, which defaults to `omit`
- `smoke_tests.yml` was always ending in success, regardless of errors occurring on the test.  It will now re-raise the errors after the cleanup
- The cleanup was also updated to work properly on podman-less machines
- Finally, the CLI installation was changed to multi-step, as there are some limitations on `unarchive` (it may not follow redirects, for example: see https://github.com/ansible/ansible/issues/19985 and the note to use `get_url` on https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/unarchive_module.html#parameter-src)